### PR TITLE
Add shellcheck as an additional dependency for actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,8 @@ repos:
     rev: "v1.7.7"
     hooks:
       - id: "actionlint"
+        additional_dependencies:
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
 
   - repo: "https://github.com/kurtmckee/pre-commit-hooks"
     rev: "v1.0.0"


### PR DESCRIPTION

The actionlint pre-commit hook relies on shellcheck for some functionality,
so this PR introduces shellcheck as an `additional_dependency` for the hook.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>